### PR TITLE
manually fix syntax

### DIFF
--- a/Formula/hussar.rb
+++ b/Formula/hussar.rb
@@ -25,19 +25,12 @@ class Hussar < Formula
   end
   
   head "https://github.com/hussar-lang/hussar.git"
-  ...
 
   def install
     bin.install "hussar"
   end
 
-  def caveats; <<~EOS
-    How to use this binary
-  EOS
-  end
-
   test do
     system "#{bin}/hussar env"
-    ...
   end
 end

--- a/Formula/hussar.rb
+++ b/Formula/hussar.rb
@@ -24,8 +24,6 @@ class Hussar < Formula
     end
   end
   
-  head "https://github.com/hussar-lang/hussar.git"
-
   def install
     bin.install "hussar"
   end


### PR DESCRIPTION
There were some config issues with the goreleaser setup. This provides a fix until the new version is used in a release.